### PR TITLE
Fix trail path icon rotation to reflect correct direction

### DIFF
--- a/TrailPath/FarmHud_TrailPath.lua
+++ b/TrailPath/FarmHud_TrailPath.lua
@@ -75,7 +75,7 @@ FarmHudTrailPathPinMixin = {}
 function FarmHudTrailPathPinMixin:UpdatePin(facing,pinIcon,scale)
 	-- facing
 	if facing and IsOpened then
-		self.pin.Facing.Rotate :SetRadians(facing);
+		self.pin.Facing.Rotate :SetRadians(self.info.f - facing);
 	end
 	-- texture
 	if self.info.currentPinIcon ~= pinIcon then


### PR DESCRIPTION
Arrows would rotate when player rotated, so changed to compensate for player rotation and show direction player was going when arrow was created.