### PR TITLE
Furman repositions settings

### DIFF
--- a/FarmHud.lua
+++ b/FarmHud.lua
@@ -439,6 +439,11 @@ function FarmHudMixin:SetScales(enabled)
 	end
 	self:SetSize(size,size);
 
+	local PercentageHUDYpostion = GetScreenHeight()  * FarmHudDB.position_y 
+	local PercentageHUDXpostion = GetScreenWidth() * FarmHudDB.position_x
+
+	self:SetPoint("CENTER", parent, "CENTER", PercentageHUDXpostion,PercentageHUDYpostion);
+
 	local MinimapSize = size * FarmHudDB.hud_size;
 	local MinimapScaledSize =  MinimapSize / FarmHudDB.hud_scale;
 	MinimapMT.SetScale(Minimap,FarmHudDB.hud_scale);
@@ -571,6 +576,10 @@ do
 		elseif IsKey(key,"SuperTrackedQuest") and FarmHud_ToggleSuperTrackedQuest and FarmHud:IsShown() then
 			FarmHud_ToggleSuperTrackedQuest(ns.QuestArrowToken,FarmHudDB.SuperTrackedQuest);
 		elseif IsKey(key,"hud_size") then
+			FarmHud:SetScales();
+		elseif IsKey(key,"position_y") then
+			FarmHud:SetScales();
+		elseif IsKey(key,"position_x") then
 			FarmHud:SetScales();
 		end
 	end

--- a/FarmHud_Options.lua
+++ b/FarmHud_Options.lua
@@ -184,6 +184,16 @@ local options = {
 					type = "toggle", order = 3, width="full",
 					name = L.Rotation, desc = L.RotationDesc
 				},
+				position_x = {
+					type = "range", order = 4,
+					name = L.HudPositionX, desc = L.HudPositionXDesc,
+					min = -0.5, max = 0.5, step = 0.01, isPercent = true
+				},
+				position_y = {
+					type = "range", order = 5,
+					name = L.HudPositionY, desc = L.HudPositionYDesc,
+					min = -0.5, max = 0.5, step = 0.01, isPercent = true
+				},
 				hud_scale = {
 					type = "range", order = 11,
 					name = L.HudSymbolScale, desc = L.HudSymbolScaleDesc,


### PR DESCRIPTION
Changes:

- Added percentage calculations and point setting in FarmHud
- Added x and y axis options to options menu

Here is a gif of my implementation:

<img src="https://user-images.githubusercontent.com/42456773/205921342-e07584e9-658d-4505-be42-8ed1fd558874.gif" alt="this slowpoke moves"  width="800" />